### PR TITLE
[Feat] 전화번호 인증 구현#3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 
     //coolsms
     implementation 'net.nurigo:sdk:4.3.0'
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     // Swagger openapi-ui
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.5.0'
+
+    //coolsms
+    implementation 'net.nurigo:sdk:4.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/midnear/midnearshopping/config/RedisConfig.java
+++ b/src/main/java/com/midnear/midnearshopping/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.midnear.midnearshopping.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories // Redis 레포지토리 기능 활성화
+public class RedisConfig {
+    private final RedisProperties redisProperties; // Redis 속성 정보 주입
+
+    @Bean // 스프링 컨텍스트에 RedisConnectionFactory 빈 등록
+    public RedisConnectionFactory redisConnectionFactory(){
+        // LettuceConnectionFactory를 사용하여 Redis 연결 팩토리 생성, 호스트와 포트 정보를 사용
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>(); // RedisTemplate 인스턴스 생성
+        redisTemplate.setConnectionFactory(redisConnectionFactory()); // Redis 연결 팩토리 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer()); // 키를 문자열로 직렬화하도록 설정
+        redisTemplate.setValueSerializer(new StringRedisSerializer()); // 값을 문자열로 직렬화하도록 설정
+
+        return redisTemplate; // 설정이 완료된 RedisTemplate 인스턴스를 반환
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
+++ b/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/api/v1/member/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
-            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","member/signup", "member/login", "disruptive/**"
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","member/signup", "member/login", "disruptive/**","/sms/**"
     }; //더 열어둘 엔드포인트 여기에 추가
 
     @Bean

--- a/src/main/java/com/midnear/midnearshopping/config/SmsCertificationUtil.java
+++ b/src/main/java/com/midnear/midnearshopping/config/SmsCertificationUtil.java
@@ -1,0 +1,39 @@
+package com.midnear.midnearshopping.config;
+
+import jakarta.annotation.PostConstruct;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SmsCertificationUtil {
+
+    @Value("${coolsms.apikey}") // coolsms의 API 키 주입
+    private String apiKey;
+
+    @Value("${coolsms.apisecret}") // coolsms의 API 비밀키 주입
+    private String apiSecret;
+
+    @Value("${coolsms.fromnumber}") // 발신자 번호 주입
+    private String fromNumber;
+
+    DefaultMessageService messageService; // 메시지 서비스를 위한 객체
+
+    @PostConstruct // 의존성 주입이 완료된 후 초기화를 수행하는 메서드
+    public void init(){
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr"); // 메시지 서비스 초기화
+    }
+
+    // 단일 메시지 발송
+    public void sendSMS(String to, String certificationCode){
+        Message message = new Message(); // 새 메시지 객체 생성
+        message.setFrom(fromNumber); // 발신자 번호 설정
+        message.setTo(to); // 수신자 번호 설정
+        message.setText("[MIDNEAR] 본인확인 인증번호는 " + certificationCode + "입니다."); // 메시지 내용 설정
+
+        this.messageService.sendOne(new SingleMessageSendingRequest(message)); // 메시지 발송 요청
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/controller/SmsController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/SmsController.java
@@ -24,8 +24,12 @@ public class SmsController {
 
     @PostMapping("/send")
     public ResponseEntity<?> SendSMS(@RequestBody @Valid SmsRequestDto smsRequestDto){
-        smsService.sendSms(smsRequestDto);
-        return ResponseEntity.ok(new ApiResponse(true, "인증 문자 전송 완료", null));
+        try{
+            smsService.sendSms(smsRequestDto);
+            return ResponseEntity.ok(new ApiResponse(true, "인증 문자 전송 완료", null));
+        } catch (IllegalArgumentException ex){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse(false, ex.getMessage(), null));
+        }
     }
 
     @PostMapping("/verify")

--- a/src/main/java/com/midnear/midnearshopping/controller/SmsController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/SmsController.java
@@ -1,0 +1,27 @@
+package com.midnear.midnearshopping.controller;
+
+import com.midnear.midnearshopping.domain.dto.users.SmsRequestDto;
+import com.midnear.midnearshopping.exception.ApiResponse;
+import com.midnear.midnearshopping.service.SmsService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/sms")
+@RequiredArgsConstructor
+public class SmsController {
+
+    private final SmsService smsService;
+
+    @PostMapping("/send")
+    public ResponseEntity<?> SendSMS(@RequestBody @Valid SmsRequestDto smsRequestDto){
+        smsService.sendSms(smsRequestDto);
+        return ResponseEntity.ok(new ApiResponse(true, "인증 문자 전송 완료", null));
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/controller/SmsController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/SmsController.java
@@ -1,11 +1,14 @@
 package com.midnear.midnearshopping.controller;
 
 import com.midnear.midnearshopping.domain.dto.users.SmsRequestDto;
+import com.midnear.midnearshopping.domain.dto.users.SmsVerifyDto;
 import com.midnear.midnearshopping.exception.ApiResponse;
 import com.midnear.midnearshopping.service.SmsService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,5 +26,15 @@ public class SmsController {
     public ResponseEntity<?> SendSMS(@RequestBody @Valid SmsRequestDto smsRequestDto){
         smsService.sendSms(smsRequestDto);
         return ResponseEntity.ok(new ApiResponse(true, "인증 문자 전송 완료", null));
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<?> verifyCode(@RequestBody @Valid SmsVerifyDto smsVerifyDto){
+        boolean verify = smsService.verifyCode(smsVerifyDto);
+        if (verify) {
+            return ResponseEntity.ok(new ApiResponse(true, "인증에 성공했습니다.", null));
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse(false, "인증에 실패했습니다.", null));
+        }
     }
 }

--- a/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
@@ -1,10 +1,10 @@
 package com.midnear.midnearshopping.controller;
 
 
-import com.midnear.midnearshopping.domain.dto.member.LoginDto;
-import com.midnear.midnearshopping.domain.dto.member.UsersDto;
+import com.midnear.midnearshopping.domain.dto.users.LoginDto;
+import com.midnear.midnearshopping.domain.dto.users.UsersDto;
 import com.midnear.midnearshopping.exception.ApiResponse;
-import com.midnear.midnearshopping.service.MemberService;
+import com.midnear.midnearshopping.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/member")
 public class UsersController {
-    private final MemberService memberService;
+    private final UsersService memberService;
 
     @PostMapping("/signup")
     public ResponseEntity<?> signUp(@RequestBody UsersDto memberDto) {

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/LoginDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/LoginDto.java
@@ -1,4 +1,4 @@
-package com.midnear.midnearshopping.domain.dto.member;
+package com.midnear.midnearshopping.domain.dto.users;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/SmsRequestDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/SmsRequestDto.java
@@ -1,0 +1,16 @@
+package com.midnear.midnearshopping.domain.dto.users;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsRequestDto {
+    @NotEmpty(message = "휴대폰 번호를 입력해주세요")
+    private String phoneNum;
+}

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/SmsVerifyDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/SmsVerifyDto.java
@@ -1,0 +1,18 @@
+package com.midnear.midnearshopping.domain.dto.users;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsVerifyDto {
+    @NotNull(message = "휴대폰 번호를 입력해주세요.")
+    private String phoneNum;
+    @NotNull(message = "인증번호를 입력해주세요.")
+    private String certificationCode;
+}

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/UsersDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/UsersDto.java
@@ -1,4 +1,4 @@
-package com.midnear.midnearshopping.domain.dto.member;
+package com.midnear.midnearshopping.domain.dto.users;
 
 import com.midnear.midnearshopping.domain.vo.users.UsersVO;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/midnear/midnearshopping/domain/vo/users/CustomUserDetails.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/vo/users/CustomUserDetails.java
@@ -1,6 +1,6 @@
 package com.midnear.midnearshopping.domain.vo.users;
 
-import com.midnear.midnearshopping.domain.dto.member.UsersDto;
+import com.midnear.midnearshopping.domain.dto.users.UsersDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/midnear/midnearshopping/domain/vo/users/CustomUserDetailsService.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/vo/users/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.midnear.midnearshopping.domain.vo.users;
 
-import com.midnear.midnearshopping.domain.dto.member.UsersDto;
-import com.midnear.midnearshopping.mapper.member.UsersMapper;
+import com.midnear.midnearshopping.domain.dto.users.UsersDto;
+import com.midnear.midnearshopping.mapper.users.UsersMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/midnear/midnearshopping/domain/vo/users/SmsRepository.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/vo/users/SmsRepository.java
@@ -1,0 +1,36 @@
+package com.midnear.midnearshopping.domain.vo.users;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Repository
+public class SmsRepository {
+    private final String PREFIX = "sms:"; // Redis 키에 사용할 접두사
+    private final StringRedisTemplate stringRedisTemplate; // Redis 작업을 위한 StringRedisTemplate 객체
+
+    // SMS 인증 정보를 생성하는 메서드
+    public void createSmsCertification(String phone, String code){
+        int LIMIT_TIME = 3 * 60; // 인증 코드의 유효 시간(초), 3분 설정
+        stringRedisTemplate.opsForValue()
+                .set(PREFIX + phone, code, Duration.ofSeconds(LIMIT_TIME)); // Redis에 키와 값을 설정, 유효 시간도 함께 설정
+    }
+
+    // SMS 인증 정보를 가져오는 메서드
+    public String getSmsCertification(String phone){
+        return stringRedisTemplate.opsForValue().get(PREFIX + phone); // Redis에서 키에 해당하는 값을 가져옴
+    }
+
+    // SMS 인증 정보를 삭제하는 메서드
+    public void deleteSmsCertification(String phone){
+        stringRedisTemplate.delete(PREFIX + phone); // Redis에서 해당 키를 삭제
+    }
+
+    // 해당 키가 존재하는지 확인하는 메서드
+    public boolean hasKey(String phone){
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(PREFIX + phone)); // Redis에서 키의 존재 여부를 확인
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/domain/vo/users/UsersVO.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/vo/users/UsersVO.java
@@ -1,6 +1,6 @@
 package com.midnear.midnearshopping.domain.vo.users;
 
-import com.midnear.midnearshopping.domain.dto.member.UsersDto;
+import com.midnear.midnearshopping.domain.dto.users.UsersDto;
 import lombok.*;
 
 import java.math.BigDecimal;

--- a/src/main/java/com/midnear/midnearshopping/jwt/JwtUtil.java
+++ b/src/main/java/com/midnear/midnearshopping/jwt/JwtUtil.java
@@ -1,6 +1,6 @@
 package com.midnear.midnearshopping.jwt;
 
-import com.midnear.midnearshopping.domain.dto.member.UsersDto;
+import com.midnear.midnearshopping.domain.dto.users.UsersDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
+++ b/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
@@ -9,4 +9,6 @@ public interface UsersMapper {
     Boolean isMemberExist(String Id);
     UsersVO getMemberById(String Id);
     UsersVO getMemberByUserId(Integer userId);
+    UsersVO getMemberByPhone(String phone);
+    Boolean isMemberExistByPhone(String phone);
 }

--- a/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
+++ b/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
@@ -1,4 +1,4 @@
-package com.midnear.midnearshopping.mapper.member;
+package com.midnear.midnearshopping.mapper.users;
 
 import com.midnear.midnearshopping.domain.vo.users.UsersVO;
 import org.apache.ibatis.annotations.Mapper;

--- a/src/main/java/com/midnear/midnearshopping/service/SmsService.java
+++ b/src/main/java/com/midnear/midnearshopping/service/SmsService.java
@@ -1,0 +1,20 @@
+package com.midnear.midnearshopping.service;
+
+import com.midnear.midnearshopping.config.SmsCertificationUtil;
+import com.midnear.midnearshopping.domain.dto.users.SmsRequestDto;
+import kotlinx.serialization.Required;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SmsService {
+    private final SmsCertificationUtil smsCertificationUtil;
+
+    public void sendSms(SmsRequestDto smsRequestDto) {
+        String phoneNum=smsRequestDto.getPhoneNum();
+        String certificationCode = Integer.toString((int)(Math.random()*(999999 - 100000 + 1)) + 100000); //6자리 랜덤 난수 생성
+        smsCertificationUtil.sendSMS(phoneNum, certificationCode);
+    }
+
+}

--- a/src/main/java/com/midnear/midnearshopping/service/SmsService.java
+++ b/src/main/java/com/midnear/midnearshopping/service/SmsService.java
@@ -2,6 +2,10 @@ package com.midnear.midnearshopping.service;
 
 import com.midnear.midnearshopping.config.SmsCertificationUtil;
 import com.midnear.midnearshopping.domain.dto.users.SmsRequestDto;
+import com.midnear.midnearshopping.domain.dto.users.SmsVerifyDto;
+import com.midnear.midnearshopping.domain.vo.users.SmsRepository;
+import com.midnear.midnearshopping.domain.vo.users.UsersVO;
+import com.midnear.midnearshopping.mapper.users.UsersMapper;
 import kotlinx.serialization.Required;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,11 +14,34 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SmsService {
     private final SmsCertificationUtil smsCertificationUtil;
+    private final SmsRepository smsRepository;
+    private final UsersMapper userMapper;
 
     public void sendSms(SmsRequestDto smsRequestDto) {
-        String phoneNum=smsRequestDto.getPhoneNum();
+        String phoneNum = smsRequestDto.getPhoneNum();
+        if(userMapper.isMemberExistByPhone(phoneNum)) {
+            throw new IllegalArgumentException("이미 가입된 번호입니다. 로그인 해 주세요.");
+            // 소셜로그인 도입 한 후에 소셜로그인 유저일경우는 다르게 처리 해야할 수도... ..
+        }
+
         String certificationCode = Integer.toString((int)(Math.random()*(999999 - 100000 + 1)) + 100000); //6자리 랜덤 난수 생성
         smsCertificationUtil.sendSMS(phoneNum, certificationCode);
+        smsRepository.createSmsCertification(phoneNum, certificationCode);
+    }
+
+    public Boolean verifyCode(SmsVerifyDto smsVerifyDto) {
+        if (isVerify(smsVerifyDto.getPhoneNum(), smsVerifyDto.getCertificationCode())) { // 인증 코드 검증
+            smsRepository.deleteSmsCertification(smsVerifyDto.getPhoneNum()); // 검증이 성공하면 Redis에서 인증 코드 삭제
+            return true; // 인증 성공 반환
+        } else {
+            return false; // 인증 실패 반환
+        }
+    }
+
+    // 전화번호와 인증 코드를 검증하는 메서드
+    public boolean isVerify(String phoneNum, String certificationCode) {
+        return smsRepository.hasKey(phoneNum) && // 전화번호에 대한 키가 존재하고
+                smsRepository.getSmsCertification(phoneNum).equals(certificationCode); // 저장된 인증 코드와 입력된 인증 코드가 일치하는지 확인
     }
 
 }

--- a/src/main/java/com/midnear/midnearshopping/service/UsersService.java
+++ b/src/main/java/com/midnear/midnearshopping/service/UsersService.java
@@ -1,10 +1,10 @@
 package com.midnear.midnearshopping.service;
 
-import com.midnear.midnearshopping.domain.dto.member.LoginDto;
-import com.midnear.midnearshopping.domain.dto.member.UsersDto;
+import com.midnear.midnearshopping.domain.dto.users.LoginDto;
+import com.midnear.midnearshopping.domain.dto.users.UsersDto;
 import com.midnear.midnearshopping.domain.vo.users.UsersVO;
 import com.midnear.midnearshopping.jwt.JwtUtil;
-import com.midnear.midnearshopping.mapper.member.UsersMapper;
+import com.midnear.midnearshopping.mapper.users.UsersMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
-public class MemberService {
+public class UsersService {
     private final UsersMapper memberMapper;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JwtUtil jwtUtil;

--- a/src/main/resources/mapper/UsersMapper.xml
+++ b/src/main/resources/mapper/UsersMapper.xml
@@ -14,6 +14,11 @@
         FROM users
         WHERE id = #{id}
     </select>
+    <select id="isMemberExistByPhone" parameterType="String" resultType="Boolean">
+        SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+        FROM users
+        WHERE phone_number = #{phone}
+    </select>
     <select id="getMemberById" parameterType="string" resultType="com.midnear.midnearshopping.domain.vo.users.UsersVO">
         SELECT *
         FROM users
@@ -24,5 +29,10 @@
         SELECT *
         FROM users
         WHERE user_id = #{userId}
+    </select>
+    <select id="getMemberByPhone" parameterType="String" resultType="com.midnear.midnearshopping.domain.vo.users.UsersVO">
+        SELECT *
+        FROM users
+        WHERE phone_number = #{phone}
     </select>
 </mapper>

--- a/src/main/resources/mapper/UsersMapper.xml
+++ b/src/main/resources/mapper/UsersMapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.midnear.midnearshopping.mapper.member.UsersMapper">
+<mapper namespace="com.midnear.midnearshopping.mapper.users.UsersMapper">
     <insert id="createMember" parameterType="UsersVO">
         INSERT INTO users (
             name, id, password, phone_number, email, withdrawn, point_balance


### PR DESCRIPTION
## 📌 관련 이슈
#3
closed #3 

## ✨ 작업 내용
coolsms api 를 활용해 인증번호 발송, 레디스에 해당 인증번호를 3분 간 저장후 인증하는 로직을 구현

## 📸 스크린샷(선택)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- appication.prorperties 추가사항 생겼으니 노션에서 확인해서 업데이트 해주세요
- 테스트는 로컬에 레디스가 설치되어 있어야 가능합니다. 아래 링크 참고해서 설치해주세요
레디스 설치(깃허브에서 msi파일 다운로드)
https://pamyferret.tistory.com/9

