### PR TITLE
[Feat] 소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation 'net.nurigo:sdk:4.3.0'
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    //oauth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
+++ b/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/api/v1/member/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
-            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","member/signup", "member/login", "disruptive/**","/sms/**"
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","/user/**","/oauth/**"
     }; //더 열어둘 엔드포인트 여기에 추가
 
     @Bean
@@ -45,6 +45,7 @@ public class SecurityConfig {
         http.httpBasic(AbstractHttpConfigurer::disable);
         //JwtAuthFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
         http.addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
 
         // 권한 규칙 작성
         http.authorizeHttpRequests(authorize -> authorize

--- a/src/main/java/com/midnear/midnearshopping/controller/OAuth2Controller.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/OAuth2Controller.java
@@ -1,0 +1,61 @@
+package com.midnear.midnearshopping.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.midnear.midnearshopping.exception.ApiResponse;
+
+import com.midnear.midnearshopping.service.oauth.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oauth")
+public class OAuth2Controller {
+    private final OAuthService oAuthService;
+    //Oauth
+    @GetMapping("/login/oauth/kakao")
+    public ResponseEntity<?> kakaoLogin(@RequestParam String code){
+        try{
+            return ResponseEntity.ok(new ApiResponse(true,"카카오 로그인 성공", oAuthService.googleLogin(code)));
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
+        } catch (JsonProcessingException | IllegalArgumentException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse(false, ex.getMessage(), null));
+        }
+    }
+    //Oauth
+    @GetMapping("/login/oauth/google")
+    public ResponseEntity<?> googleLogin(@RequestParam String code){
+        try{
+            return ResponseEntity.ok(new ApiResponse(true,"구글 로그인 성공", oAuthService.googleLogin(code)));
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
+        } catch (JsonProcessingException | IllegalArgumentException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse(false, ex.getMessage(), null));
+        }
+
+    }
+    //Oauth
+    @GetMapping("/login/oauth/naver")
+    public ResponseEntity<?> naverLogin(@RequestParam String code, @RequestParam String state){
+        try{
+            return ResponseEntity.ok(new ApiResponse(true,"네이버 로그인 성공", oAuthService.naverLogin(code, state)));
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
+        } catch (JsonProcessingException | IllegalArgumentException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse(false, ex.getMessage(), null));
+        }
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
@@ -4,7 +4,10 @@ package com.midnear.midnearshopping.controller;
 import com.midnear.midnearshopping.domain.dto.users.LoginDto;
 import com.midnear.midnearshopping.domain.dto.users.UsersDto;
 import com.midnear.midnearshopping.exception.ApiResponse;
+
+
 import com.midnear.midnearshopping.service.UsersService;
+import com.midnear.midnearshopping.service.oauth.OAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/member")
+@RequestMapping("/user")
 public class UsersController {
     private final UsersService memberService;
 
@@ -61,4 +64,5 @@ public class UsersController {
         }
 
     }
+
 }

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/SocialUserInfoDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/SocialUserInfoDto.java
@@ -1,0 +1,16 @@
+package com.midnear.midnearshopping.domain.dto.users;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@Builder
+public class SocialUserInfoDto {
+    private String id;
+    private String email;
+    private String name;
+    private String phone;
+    private String nickname;
+}

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/UsersDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/UsersDto.java
@@ -23,6 +23,7 @@ public class UsersDto {
     private String phoneNumber;
     @NotBlank(message = "이메일을 입력해주세요")
     private String email;
+    private String socialType;
 
     public static UsersDto toDto(UsersVO member) {
         return new UsersDto(
@@ -31,7 +32,8 @@ public class UsersDto {
                 member.getId(),
                 member.getPassword(),
                 member.getPhoneNumber(),
-                member.getEmail()
+                member.getEmail(),
+                member.getSocialType()
         );
     }
 

--- a/src/main/java/com/midnear/midnearshopping/domain/vo/users/UsersVO.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/vo/users/UsersVO.java
@@ -9,8 +9,6 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-//INT는 Integer로, Decimal은 BigDecimal로 매핑이 권장된다길래 그리 했습니다.
-//코드 리뷰시 이렇게 진행해도 괜찮을지 코멘트 부탁드려요
 
 public class UsersVO {
     private Integer userId;
@@ -21,6 +19,7 @@ public class UsersVO {
     private String email;
     private String withdrawn= "N";
     private BigDecimal pointBalance;
+    private String socialType;
 
     public static UsersVO toEntity(UsersDto memberDto) {
         return UsersVO.builder()

--- a/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
+++ b/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
@@ -10,5 +10,6 @@ public interface UsersMapper {
     UsersVO getMemberById(String Id);
     UsersVO getMemberByUserId(Integer userId);
     UsersVO getMemberByPhone(String phone);
+    UsersVO getMemberByEmail(String email);
     Boolean isMemberExistByPhone(String phone);
 }

--- a/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthGoogleProvider.java
+++ b/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthGoogleProvider.java
@@ -1,0 +1,67 @@
+package com.midnear.midnearshopping.service.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class OAuthGoogleProvider implements OAuthProvider {
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public String getAccessToken(String code) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", code);
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("grant_type", "authorization_code");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "https://oauth2.googleapis.com/token", request, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    @Override
+    public Map<String, Object> getUserInfo(String accessToken) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<?> request = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://www.googleapis.com/oauth2/v3/userinfo", HttpMethod.GET, request, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(response.getBody(), HashMap.class);
+    }
+}
+

--- a/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthKaKaoProvider.java
+++ b/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthKaKaoProvider.java
@@ -1,0 +1,64 @@
+package com.midnear.midnearshopping.service.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class OAuthKaKaoProvider implements OAuthProvider {
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public String getAccessToken(String code) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "https://kauth.kakao.com/oauth/token", request, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    @Override
+    public Map<String, Object> getUserInfo(String accessToken) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<?> request = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me", HttpMethod.GET, request, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(response.getBody(), HashMap.class);
+    }
+}
+

--- a/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthNaverProvider.java
+++ b/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthNaverProvider.java
@@ -1,0 +1,74 @@
+package com.midnear.midnearshopping.service.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class OAuthNaverProvider implements OAuthProvider {
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public String getAccessToken(String code, String state) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "https://nid.naver.com/oauth2.0/token", request, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    @Override
+    public Map<String, Object> getUserInfo(String accessToken) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<?> request = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://openapi.naver.com/v1/nid/me", HttpMethod.GET, request, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(response.getBody(), HashMap.class);
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        throw new UnsupportedOperationException("Naver requires state parameter");
+    }
+}
+
+

--- a/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthProvider.java
+++ b/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthProvider.java
@@ -1,0 +1,16 @@
+package com.midnear.midnearshopping.service.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.util.Map;
+
+public interface OAuthProvider {
+    default String getAccessToken(String code, String state) throws JsonProcessingException {
+        return getAccessToken(code);
+    }
+
+    String getAccessToken(String code) throws JsonProcessingException;
+
+    Map<String, Object> getUserInfo(String accessToken) throws JsonProcessingException;
+}
+

--- a/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthService.java
+++ b/src/main/java/com/midnear/midnearshopping/service/oauth/OAuthService.java
@@ -1,0 +1,105 @@
+package com.midnear.midnearshopping.service.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.midnear.midnearshopping.domain.dto.users.SocialUserInfoDto;
+import com.midnear.midnearshopping.domain.dto.users.UsersDto;
+import com.midnear.midnearshopping.domain.vo.users.UsersVO;
+import com.midnear.midnearshopping.jwt.JwtUtil;
+import com.midnear.midnearshopping.mapper.users.UsersMapper;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+    private final UsersMapper usersMapper;
+    private final JwtUtil jwtUtil;
+    private final OAuthKaKaoProvider kakaoOAuthProvider;
+    private final OAuthGoogleProvider googleOAuthProvider;
+    private final OAuthNaverProvider naverOAuthProvider;
+
+    public String kakaoLogin(String code) throws JsonProcessingException, IllegalAccessException {
+        String accessToken = kakaoOAuthProvider.getAccessToken(code);
+        Map<String, Object> userInfo = kakaoOAuthProvider.getUserInfo(accessToken);
+        SocialUserInfoDto user = extractKakaoUserInfo(userInfo);
+        return userLogin(user, "kakao");
+    }
+
+    public String googleLogin(String code) throws JsonProcessingException, IllegalArgumentException {
+        String accessToken = googleOAuthProvider.getAccessToken(code);
+        Map<String, Object> userInfo = googleOAuthProvider.getUserInfo(accessToken);
+        SocialUserInfoDto user = extractGoogleUserInfo(userInfo);
+        return userLogin(user, "google");
+    }
+
+    public String naverLogin(String code, String state) throws JsonProcessingException, IllegalArgumentException {
+        String accessToken = naverOAuthProvider.getAccessToken(code, state);
+        Map<String, Object> userInfo = naverOAuthProvider.getUserInfo(accessToken);
+        SocialUserInfoDto user = extractNaverUserInfo(userInfo);
+        return userLogin(user, "naver");
+    }
+
+    private String userLogin(SocialUserInfoDto userInfo, String provider) throws IllegalArgumentException {
+        UsersVO user = usersMapper.getMemberByEmail(userInfo.getEmail());
+
+        if (user == null) { // 회원가입
+            user = new UsersVO();
+            user.setName(userInfo.getName());
+            user.setId(userInfo.getId());
+            user.setEmail(userInfo.getEmail());
+            user.setPhoneNumber(userInfo.getPhone());
+            user.setWithdrawn("Y"); // 기본값 설정 (추후 논의)
+            user.setSocialType(provider);
+            usersMapper.createMember(user);
+        }
+        if(!Objects.equals(user.getSocialType(), provider)){
+            throw new IllegalArgumentException("다른 소셜 계정 혹은 일반 로그인에 등록된 이메일입니다.");
+        }
+
+        // JWT 토큰 생성 및 반환
+        return jwtUtil.createAccessToken(UsersDto.toDto(user));
+    }
+    public SocialUserInfoDto extractKakaoUserInfo(Map<String, Object> userInfo) {
+        String rawPhone = userInfo.containsKey("phone") ? userInfo.get("phone").toString() : null;
+        String formattedPhone = (rawPhone != null) ? rawPhone.replace("-", "") : null; // "-" 제거
+
+        return SocialUserInfoDto.builder()
+                .id(userInfo.get("id").toString())
+                .email(userInfo.containsKey("email") ? userInfo.get("email").toString() : null)
+                .name(userInfo.containsKey("nickname") ? userInfo.get("nickname").toString() : null)
+                .phone(formattedPhone) // 포맷팅된 전화번호 사용
+                .nickname(userInfo.containsKey("nickname") ? userInfo.get("nickname").toString() : null)
+                .build();
+    }
+
+    public SocialUserInfoDto extractGoogleUserInfo(Map<String, Object> userInfo) {
+        return SocialUserInfoDto.builder()
+                .id(userInfo.get("sub").toString()) // 구글은 "sub" 필드가 사용자 ID
+                .email(userInfo.get("email").toString())
+                .name(userInfo.getOrDefault("name", "Unknown").toString())
+                .phone(null) // 구글 API에서 기본적으로 전화번호는 제공하지 않음... 하 이거 따로 받아야할거같은데요 sibal jinjja johnaj jangna...
+                .nickname(null) // 구글은 닉네임 정보 없음
+                .build();
+    }
+
+    public SocialUserInfoDto extractNaverUserInfo(Map<String, Object> userInfo) {
+        Map<String, Object> response = (Map<String, Object>) userInfo.get("response"); // 네이버는 "response" 내부에 데이터가 있음
+        String rawPhone = response.getOrDefault("mobile", "").toString(); // 원래의 전화번호
+        String formattedPhone = rawPhone.replace("-", ""); // "-" 제거
+
+        return SocialUserInfoDto.builder()
+                .id(response.get("id").toString())
+                .email(response.get("email").toString())
+                .name(response.get("name").toString())
+                .phone(formattedPhone) // 포맷팅된 전화번호 사용
+                .nickname(response.getOrDefault("nickname", null).toString())
+                .build();
+    }
+
+}

--- a/src/main/resources/mapper/UsersMapper.xml
+++ b/src/main/resources/mapper/UsersMapper.xml
@@ -3,9 +3,9 @@
 <mapper namespace="com.midnear.midnearshopping.mapper.users.UsersMapper">
     <insert id="createMember" parameterType="UsersVO">
         INSERT INTO users (
-            name, id, password, phone_number, email, withdrawn, point_balance
+            name, id, password, phone_number, email, withdrawn, point_balance, social_type
         ) VALUES (
-                     #{name}, #{id}, #{password}, #{phoneNumber}, #{email}, #{withdrawn}, #{pointBalance}
+                     #{name}, #{id}, #{password}, #{phoneNumber}, #{email}, #{withdrawn}, #{pointBalance}, #{socialType}
                  )
 
     </insert>
@@ -34,5 +34,10 @@
         SELECT *
         FROM users
         WHERE phone_number = #{phone}
+    </select>
+    <select id="getMemberByEmail" parameterType="String" resultType="com.midnear.midnearshopping.domain.vo.users.UsersVO">
+        SELECT *
+        FROM users
+        WHERE email = #{email}
     </select>
 </mapper>

--- a/src/main/resources/project.sql
+++ b/src/main/resources/project.sql
@@ -1,10 +1,10 @@
 CREATE TABLE `users` (
     `user_id` int NOT NULL AUTO_INCREMENT,
     `name` varchar(20) NULL,
-    `id` varchar(20) NULL,
+    `id` varchar(50) NULL,
     `password` varchar(255) NULL,
     `phone_number` varchar(20) NULL,
-    `email` varchar(20) NULL,
+    `email` varchar(50) NULL,
     `withdrawn` varchar(20) NULL DEFAULT 'N',
     `point_balance` decimal NULL,
      PRIMARY KEY (`user_id`),


### PR DESCRIPTION
## 📌 관련 이슈
#15  

## ✨ 작업 내용
-유저에 소셜카입 컬럼추가
-유저 아이디, 이메일 길이 제한 늘림
-네이버, 카카오, 구글 로그임 및 회원가입, 로그인 구현

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
지금은 배포가 안된 상태라 리다이렉트 uri및 기타 설정들이 불완전함. 배포 이후 몇 가지 갈아 엎어야 함.
구글 로그인의 경우 유저 전화번호를 제공해주지 않아서 이에 대한 논의가 필요함. 바로 입력하게 할지 주문시 전화번호 입력을 요구할 지 고민중입니다.
