### PR TITLE
[Feat] 유저 정보 조회, 수정, 이메일 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     //oauth
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // 인증 Email에 필요한 것
+    implementation 'com.sun.mail:javax.mail:1.6.2'
+    implementation 'org.springframework:spring-context-support:5.3.9'
+    implementation 'org.hibernate.validator:hibernate-validator:6.1.7.Final'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/midnear/midnearshopping/config/EmailCertificationUtil.java
+++ b/src/main/java/com/midnear/midnearshopping/config/EmailCertificationUtil.java
@@ -1,0 +1,47 @@
+package com.midnear.midnearshopping.config;
+import com.midnear.midnearshopping.domain.vo.users.EmailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+@Component
+@RequiredArgsConstructor
+public class EmailCertificationUtil {
+    @Value("${spring.mail.username}") // coolsms의 API 키 주입
+    private String sender;
+    private final JavaMailSender mailSender;
+    private final EmailRepository emailRepository;
+
+
+    public void sendEmail(String email, String code) throws MessagingException {
+        String title = "[MIDNEAR]인증 이메일 입니다."; // 이메일 제목
+        String content =
+                "비밀번호 찾기 인증번호 이메일 입니다." + 	//html 형식으로 작성
+                        "<br><br>" +
+                        "인증 번호는 " + code + "입니다." +
+                        "<br>" +
+                        "인증번호를 제대로 입력해주세요";
+        send(email, title, content, code);
+
+    }
+
+    //이메일을 전송
+    private void send(String sendTo, String title, String content, String code) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+
+        MimeMessageHelper helper = new MimeMessageHelper(message,true,"utf-8");
+        helper.setFrom(sender);
+        helper.setTo(sendTo);
+        helper.setSubject(title);
+        helper.setText(content,true);
+        mailSender.send(message);
+
+        emailRepository.createEmailCertification(sendTo, code);
+
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/config/EmailConfig.java
+++ b/src/main/java/com/midnear/midnearshopping/config/EmailConfig.java
@@ -1,0 +1,38 @@
+package com.midnear.midnearshopping.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${spring.mail.username}")
+    private String sender;
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender mailSender() {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(sender); // 구글 이메일
+        mailSender.setPassword(password); // 구글 인증 비밀번호
+
+        Properties javaMailProperties = new Properties();
+        javaMailProperties.put("mail.transport.protocol", "smtp");
+        javaMailProperties.put("mail.smtp.auth", "true");
+        javaMailProperties.put("mail.smtp.starttls.enable", "true");
+        javaMailProperties.put("mail.debug", "true");
+        javaMailProperties.put("mail.smtp.ssl.trust", "smtp.gmail.com");// 모든 서버를 신뢰하도록 설정
+
+        mailSender.setJavaMailProperties(javaMailProperties);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
+++ b/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
             "/api/v1/member/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","/oauth/**",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","user/signup", "user/login","user/find-id", "disruptive/**","/sms/**","/inquirie/**"
-            ,"/magazine/**", "/email/**", "/user/is-duplicate", "/user/find-by-email", "/user/change-password"
+            ,"/magazine/**", "/email/**", "/user/is-duplicate", "/user/find-by-email", "/user/change-password", "/user/change-user-info", "/user/user-info"
     }; //더 열어둘 엔드포인트 여기에 추가
 
     @Bean

--- a/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
+++ b/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
             "/api/v1/member/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","/user/**","/oauth/**",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","user/signup", "user/login","user/findId", "disruptive/**","/sms/**","/inquirie/**"
-            ,"/magazine/**"
+            ,"/magazine/**", "/email/**"
     }; //더 열어둘 엔드포인트 여기에 추가
 
     @Bean

--- a/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
+++ b/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
@@ -23,9 +23,9 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/api/v1/member/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
-            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","/user/**","/oauth/**",
-            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","user/signup", "user/login","user/findId", "disruptive/**","/sms/**","/inquirie/**"
-            ,"/magazine/**", "/email/**"
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","/oauth/**",
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","user/signup", "user/login","user/find-id", "disruptive/**","/sms/**","/inquirie/**"
+            ,"/magazine/**", "/email/**", "/user/is-duplicate", "/user/find-by-email", "/user/change-password"
     }; //더 열어둘 엔드포인트 여기에 추가
 
     @Bean

--- a/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
+++ b/src/main/java/com/midnear/midnearshopping/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/api/v1/member/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","/user/**","/oauth/**",
-            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","member/signup", "member/login", "disruptive/**","/sms/**","/inquirie/**"
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**","user/signup", "user/login","user/findId", "disruptive/**","/sms/**","/inquirie/**"
             ,"/magazine/**"
     }; //더 열어둘 엔드포인트 여기에 추가
 

--- a/src/main/java/com/midnear/midnearshopping/controller/EmailController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/EmailController.java
@@ -1,13 +1,13 @@
 package com.midnear.midnearshopping.controller;
 
+import com.midnear.midnearshopping.domain.dto.users.EmailRequestDto;
+import com.midnear.midnearshopping.domain.dto.users.EmailVerifyDto;
 import com.midnear.midnearshopping.domain.dto.users.SmsRequestDto;
 import com.midnear.midnearshopping.domain.dto.users.SmsVerifyDto;
 import com.midnear.midnearshopping.exception.ApiResponse;
-import com.midnear.midnearshopping.service.SmsService;
+import com.midnear.midnearshopping.service.MailSendService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,31 +15,35 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController
-@RequestMapping("/sms")
-@RequiredArgsConstructor
-public class SmsController {
+import javax.mail.MessagingException;
 
-    private final SmsService smsService;
+@RestController
+@RequestMapping("/email")
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final MailSendService mailSendService;
 
     @PostMapping("/send")
-    public ResponseEntity<?> SendSMS(@RequestBody @Valid SmsRequestDto smsRequestDto) {
-        try {
-            smsService.sendSms(smsRequestDto);
-            return ResponseEntity.ok(new ApiResponse(true, "인증 문자 전송 완료", null));
-        } catch (IllegalArgumentException ex) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse(false, ex.getMessage(), null));
+    public ResponseEntity<?> SendEmail(@RequestBody @Valid EmailRequestDto emailRequestDto){
+        try{
+            mailSendService.sendEmail(emailRequestDto);
+            return ResponseEntity.ok(new ApiResponse(true, "인증 이메일 전송 완료", null));
+        } catch (MessagingException ex){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ApiResponse(false, "인증 메일 전송 중 오류가 발생했습니다. 다시 시도해주세요.", null));
         }
     }
 
     @PostMapping("/verify")
-    public ResponseEntity<?> verifyCode(@RequestBody @Valid SmsVerifyDto smsVerifyDto) {
-        boolean verify = smsService.verifyCode(smsVerifyDto);
+    public ResponseEntity<?> verifyEmail(@RequestBody @Valid EmailVerifyDto emailVerifyDto){
+        boolean verify = mailSendService.verifyCode(emailVerifyDto);
         if (verify) {
             return ResponseEntity.ok(new ApiResponse(true, "인증에 성공했습니다.", null));
         } else {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse(false, "인증에 실패했습니다.", null));
         }
     }
+
+
 
 }

--- a/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
@@ -7,7 +7,6 @@ import com.midnear.midnearshopping.exception.ApiResponse;
 
 
 import com.midnear.midnearshopping.service.UsersService;
-import com.midnear.midnearshopping.service.oauth.OAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,7 +51,7 @@ public class UsersController {
     }
 
     @GetMapping("/isDuplicate")
-    public ResponseEntity<String> isDuplicate(String id) {
+    public ResponseEntity<String> isDuplicate(@RequestParam String id) {
         try {
             Boolean result = memberService.isDuplicate(id);
             if (result) {
@@ -62,7 +61,15 @@ public class UsersController {
         } catch (Exception e) {
             return ResponseEntity.status(500).body("중복확인 중 오류가 발생했습니다.");
         }
-
     }
 
+    @GetMapping("/findId")
+    public ResponseEntity<?> findId(@RequestParam String phone) {
+        try {
+            String id = memberService.findIdByPhone(phone);
+            return ResponseEntity.ok(new ApiResponse(true, "아이디 찾기 성공", id));
+        } catch (Exception ex) {
+            return ResponseEntity.status(404).body(new ApiResponse(false, ex.getMessage(), null));
+        }
+    }
 }

--- a/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
@@ -2,15 +2,19 @@ package com.midnear.midnearshopping.controller;
 
 
 import com.midnear.midnearshopping.domain.dto.users.LoginDto;
+import com.midnear.midnearshopping.domain.dto.users.UserInfoChangeDto;
 import com.midnear.midnearshopping.domain.dto.users.UsersDto;
+import com.midnear.midnearshopping.domain.vo.users.CustomUserDetails;
 import com.midnear.midnearshopping.exception.ApiResponse;
 
 
+import com.midnear.midnearshopping.service.CustomUserDetailsService;
 import com.midnear.midnearshopping.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
@@ -86,13 +90,46 @@ public class UsersController {
     @PatchMapping("/change-password")
     public ResponseEntity<?> changePassword(@RequestBody LoginDto loginDto) {
         try{
-            memberService.changePassword(loginDto.getId(), loginDto.getPassword());
-            return ResponseEntity.ok(new ApiResponse(true, "비밀번호 변경 성공", loginDto.getId()));
+            String id = memberService.changePassword(loginDto.getId(), loginDto.getPassword());
+            return ResponseEntity.ok(new ApiResponse(true, "비밀번호 변경 성공", id));
         }catch (IllegalArgumentException ex){
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse(false, ex.getMessage(), null));
 
         }catch (UsernameNotFoundException ex){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse(false, ex.getMessage(), null));
+        }
+    }
+    @GetMapping("/check-password")
+    public ResponseEntity<?> checkPassword(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestParam String password) {
+        try {
+            Boolean result = memberService.checkPassword(customUserDetails.getUsername(), password);
+            if (result) {
+                return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse(true, "비밀번호가 일치합니다.", null));
+            }
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse(false, "비밀번호가 일치하지 않습니다.", null));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ApiResponse(false, "비밀번호 확인 중 에러가 발생했습니다\n." + e.getMessage(), null));
+        }
+    }
+
+    @GetMapping("/user-info")
+    public ResponseEntity<ApiResponse> getUserInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        try {
+            UserInfoChangeDto result = memberService.getUserInfo(customUserDetails.getUsername());
+            return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse(true, "유저 정보 조회 성공", result));
+
+        } catch (UsernameNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse(false, "유저 정보 확인 중 에러가 발생했습니다\n." + e.getMessage(), null));
+        }
+    }
+    @PutMapping("/change-user-info")
+    public ResponseEntity<ApiResponse> getUserInfo(@RequestBody UserInfoChangeDto userInfoChangeDto) {
+        try {
+            memberService.changeUserInfo(userInfoChangeDto);
+            return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse(true, "유저 정보 변경 완료", null));
+
+        } catch (UsernameNotFoundException | IllegalArgumentException ex) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse(false, ex.getMessage(), null));
         }
     }
 }

--- a/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
+++ b/src/main/java/com/midnear/midnearshopping/controller/UsersController.java
@@ -50,7 +50,7 @@ public class UsersController {
         }
     }
 
-    @GetMapping("/isDuplicate")
+    @GetMapping("/is-duplicate")
     public ResponseEntity<String> isDuplicate(@RequestParam String id) {
         try {
             Boolean result = memberService.isDuplicate(id);
@@ -63,13 +63,36 @@ public class UsersController {
         }
     }
 
-    @GetMapping("/findId")
+    @GetMapping("/find-id")
     public ResponseEntity<?> findId(@RequestParam String phone) {
         try {
             String id = memberService.findIdByPhone(phone);
             return ResponseEntity.ok(new ApiResponse(true, "아이디 찾기 성공", id));
         } catch (Exception ex) {
             return ResponseEntity.status(404).body(new ApiResponse(false, ex.getMessage(), null));
+        }
+    }
+
+    @GetMapping("/find-by-email")
+    public ResponseEntity<?> findByEmail(@RequestParam String email) {
+        try {
+            String id = memberService.findIdByEmail(email);
+            return ResponseEntity.ok(new ApiResponse(true, "아이디 찾기 성공", id));
+        } catch (Exception ex) {
+            return ResponseEntity.status(404).body(new ApiResponse(false, ex.getMessage(), null));
+        }
+    }
+
+    @PatchMapping("/change-password")
+    public ResponseEntity<?> changePassword(@RequestBody LoginDto loginDto) {
+        try{
+            memberService.changePassword(loginDto.getId(), loginDto.getPassword());
+            return ResponseEntity.ok(new ApiResponse(true, "비밀번호 변경 성공", loginDto.getId()));
+        }catch (IllegalArgumentException ex){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse(false, ex.getMessage(), null));
+
+        }catch (UsernameNotFoundException ex){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse(false, ex.getMessage(), null));
         }
     }
 }

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/EmailRequestDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/EmailRequestDto.java
@@ -1,0 +1,16 @@
+package com.midnear.midnearshopping.domain.dto.users;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailRequestDto {
+    @NotEmpty(message = "이메일을 입력해주세요")
+    private String email;
+}

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/EmailVerifyDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/EmailVerifyDto.java
@@ -1,0 +1,18 @@
+package com.midnear.midnearshopping.domain.dto.users;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailVerifyDto {
+    @NotNull(message = "이메일을 입력해주세요.")
+    private String email;
+    @NotNull(message = "인증번호를 입력해주세요.")
+    private String certificationCode;
+}

--- a/src/main/java/com/midnear/midnearshopping/domain/dto/users/UserInfoChangeDto.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/dto/users/UserInfoChangeDto.java
@@ -1,0 +1,28 @@
+package com.midnear.midnearshopping.domain.dto.users;
+
+import com.midnear.midnearshopping.domain.vo.users.UsersVO;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoChangeDto {
+
+    private String name;
+    private String id;
+    private String phoneNumber;
+    private String email;
+    private String socialType;
+
+    public static UserInfoChangeDto toDto(UsersVO user) {
+        return new UserInfoChangeDto(
+                user.getName(),
+                user.getId(),
+                user.getPhoneNumber(),
+                user.getEmail(),
+                user.getSocialType()
+        );
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/domain/vo/users/EmailRepository.java
+++ b/src/main/java/com/midnear/midnearshopping/domain/vo/users/EmailRepository.java
@@ -1,0 +1,37 @@
+package com.midnear.midnearshopping.domain.vo.users;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Repository
+public class EmailRepository {
+    private final String PREFIX = "email:"; // Redis 키에 사용할 접두사
+    private final StringRedisTemplate stringRedisTemplate; // Redis 작업을 위한 StringRedisTemplate 객체
+
+    // Email 인증 정보를 생성하는 메서드
+    public void createEmailCertification(String email, String code){
+        int LIMIT_TIME = 3 * 60; // 인증 코드의 유효 시간(초), 3분 설정
+        stringRedisTemplate.opsForValue()
+                .set(PREFIX + email, code, Duration.ofSeconds(LIMIT_TIME)); // Redis에 키와 값을 설정, 유효 시간도 함께 설정
+    }
+
+    // SMS 인증 정보를 가져오는 메서드
+    public String getEmailCertification(String email){
+        return stringRedisTemplate.opsForValue().get(PREFIX + email); // Redis에서 키에 해당하는 값을 가져옴
+    }
+
+    // SMS 인증 정보를 삭제하는 메서드
+    public void deleteEmailCertification(String email){
+        stringRedisTemplate.delete(PREFIX + email); // Redis에서 해당 키를 삭제
+    }
+
+    // 해당 키가 존재하는지 확인하는 메서드
+    public boolean hasKey(String email){
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(PREFIX + email)); // Redis에서 키의 존재 여부를 확인
+    }
+
+}

--- a/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
+++ b/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
@@ -12,4 +12,5 @@ public interface UsersMapper {
     UsersVO getMemberByPhone(String phone);
     UsersVO getMemberByEmail(String email);
     Boolean isMemberExistByPhone(String phone);
+    int updatePassword(UsersVO user);
 }

--- a/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
+++ b/src/main/java/com/midnear/midnearshopping/mapper/users/UsersMapper.java
@@ -1,5 +1,6 @@
 package com.midnear.midnearshopping.mapper.users;
 
+import com.midnear.midnearshopping.domain.dto.users.UserInfoChangeDto;
 import com.midnear.midnearshopping.domain.vo.users.UsersVO;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -13,4 +14,6 @@ public interface UsersMapper {
     UsersVO getMemberByEmail(String email);
     Boolean isMemberExistByPhone(String phone);
     int updatePassword(UsersVO user);
+    String getPasswordById(String id);
+    void updateUserInfo(UserInfoChangeDto userInfoChangeDto);
 }

--- a/src/main/java/com/midnear/midnearshopping/service/MailSendService.java
+++ b/src/main/java/com/midnear/midnearshopping/service/MailSendService.java
@@ -1,0 +1,40 @@
+package com.midnear.midnearshopping.service;
+
+import com.midnear.midnearshopping.config.EmailCertificationUtil;
+import com.midnear.midnearshopping.domain.dto.users.EmailRequestDto;
+import com.midnear.midnearshopping.domain.dto.users.EmailVerifyDto;
+import com.midnear.midnearshopping.domain.vo.users.EmailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import javax.mail.MessagingException;
+
+@RequiredArgsConstructor
+@Service
+public class MailSendService {
+
+    private final EmailRepository emailRepository;
+    private final EmailCertificationUtil emailCertificationUtil;
+
+    public void sendEmail(EmailRequestDto emailRequestDto) throws MessagingException {
+        String email = emailRequestDto.getEmail();
+
+        String certificationCode = Integer.toString((int)(Math.random()*(999999 - 100000 + 1)) + 100000); //6자리 랜덤 난수 생성
+        emailCertificationUtil.sendEmail(email, certificationCode);
+        emailRepository.createEmailCertification(email, certificationCode);
+    }
+
+    public Boolean verifyCode(EmailVerifyDto emailVerifyDto) {
+        if (isVerify(emailVerifyDto.getEmail(), emailVerifyDto.getCertificationCode())) { // 인증 코드 검증
+            emailRepository.deleteEmailCertification(emailVerifyDto.getEmail()); // 검증이 성공하면 Redis에서 인증 코드 삭제
+            return true; // 인증 성공 반환
+        } else {
+            return false; // 인증 실패 반환
+        }
+    }
+
+    // 메일과 인증 코드를 검증하는 메서드
+    private boolean isVerify(String email, String certificationCode) {
+        return emailRepository.hasKey(email) && // 이메일에 대한 키가 존재하고
+                emailRepository.getEmailCertification(email).equals(certificationCode); // 저장된 인증 코드와 입력된 인증 코드가 일치하는지 확인
+    }
+}

--- a/src/main/java/com/midnear/midnearshopping/service/UsersService.java
+++ b/src/main/java/com/midnear/midnearshopping/service/UsersService.java
@@ -56,8 +56,42 @@ public class UsersService {
         if (user == null) {
             throw new UsernameNotFoundException("해당 번호로 가입된 아이디가 존재하지 않습니다. 문제가 계속 될 경우 고객센터로 문의하시기 바랍니다.");
         }
+        if (user.getSocialType().equals("kakao") || user.getSocialType().equals("google") || user.getSocialType().equals("naver")) {
+            throw new IllegalArgumentException("소셜 계정으로 가입된 전화번호 입니다. 소셜 로그인을 시도해주세요.");
+        }
         return user.getId();
     }
+
+    public String findIdByEmail(String email) {
+        UsersVO user = usersMapper.getMemberByEmail(email);
+        if (user == null) {
+            throw new UsernameNotFoundException("해당 이메일로 가입된 아이디가 존재하지 않습니다. 문제가 계속 될 경우 고객센터로 문의하시기 바랍니다.");
+        }
+        if (user.getSocialType()!=null) {
+            throw new IllegalArgumentException("소셜 계정으로 가입된 이메일 입니다. 소셜 로그인을 시도해주세요.");
+        }
+        return user.getId();
+    }
+
+    @Transactional
+    public String changePassword(String id, String password) {
+        UsersVO user = usersMapper.getMemberById(id);
+        if (user == null) {
+            throw new UsernameNotFoundException("해당 번호로 가입된 아이디가 존재하지 않습니다. 문제가 계속 될 경우 고객센터로 문의하시기 바랍니다.");
+        }
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        String encodedPassword = passwordEncoder.encode(password);
+
+        user.setPassword(encodedPassword);
+        int updateCount = usersMapper.updatePassword(user);
+
+        if (updateCount == 0) {
+            throw new RuntimeException("비밀번호 변경에 실패했습니다. 다시 시도해주세요.");
+        }
+        return user.getId();
+    }
+
+
 
 }
 

--- a/src/main/java/com/midnear/midnearshopping/service/UsersService.java
+++ b/src/main/java/com/midnear/midnearshopping/service/UsersService.java
@@ -18,11 +18,15 @@ public class UsersService {
     private final UsersMapper memberMapper;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JwtUtil jwtUtil;
+    private final UsersMapper usersMapper;
 
     @Transactional
     public void signUp(UsersDto memberDto) {
         if(memberMapper.isMemberExist(memberDto.getId())){
             throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
+        if(memberMapper.isMemberExistByPhone(memberDto.getId())){
+            throw new IllegalArgumentException("이미 가입된 전화번호 입니다.");
         }
         memberDto.setPassword(bCryptPasswordEncoder.encode(memberDto.getPassword()));
         memberMapper.createMember(UsersVO.toEntity(memberDto));
@@ -45,6 +49,14 @@ public class UsersService {
 
     public Boolean isDuplicate(String id){
         return memberMapper.isMemberExist(id);
+    }
+
+    public String findIdByPhone(String phone) {
+        UsersVO user = usersMapper.getMemberByPhone(phone);
+        if (user == null) {
+            throw new UsernameNotFoundException("해당 번호로 가입된 아이디가 존재하지 않습니다. 문제가 계속 될 경우 고객센터로 문의하시기 바랍니다.");
+        }
+        return user.getId();
     }
 
 }

--- a/src/main/java/com/midnear/midnearshopping/service/UsersService.java
+++ b/src/main/java/com/midnear/midnearshopping/service/UsersService.java
@@ -1,6 +1,7 @@
 package com.midnear.midnearshopping.service;
 
 import com.midnear.midnearshopping.domain.dto.users.LoginDto;
+import com.midnear.midnearshopping.domain.dto.users.UserInfoChangeDto;
 import com.midnear.midnearshopping.domain.dto.users.UsersDto;
 import com.midnear.midnearshopping.domain.vo.users.UsersVO;
 import com.midnear.midnearshopping.jwt.JwtUtil;
@@ -89,6 +90,35 @@ public class UsersService {
             throw new RuntimeException("비밀번호 변경에 실패했습니다. 다시 시도해주세요.");
         }
         return user.getId();
+    }
+
+    public Boolean checkPassword(String id, String password) {
+        String originPwd = memberMapper.getPasswordById(id);
+        return bCryptPasswordEncoder.matches(originPwd, password);
+    }
+
+    public UserInfoChangeDto getUserInfo(String id){
+        UsersVO user = usersMapper.getMemberById(id);
+        if (user == null) {
+            throw new UsernameNotFoundException("존재하지 않는 유저입니다.");
+        }
+        return UserInfoChangeDto.toDto(user);
+
+    }
+
+    @Transactional
+    public void changeUserInfo(UserInfoChangeDto userInfoChangeDto) {
+        UsersVO user = usersMapper.getMemberById(userInfoChangeDto.getId());
+        if (user == null) {
+            throw new UsernameNotFoundException("존재하지 않는 유저입니다.");
+        }
+        if (user.getSocialType()!=null) {
+            throw new UsernameNotFoundException("소셜 계정으로 가입된 회원은 이메일 변경이 불가능 합니다.");
+        }
+        usersMapper.updateUserInfo(userInfoChangeDto);
+
+
+
     }
 
 

--- a/src/main/resources/mapper/UsersMapper.xml
+++ b/src/main/resources/mapper/UsersMapper.xml
@@ -45,4 +45,16 @@
         SET password = #{password}
         WHERE id = #{id}
     </update>
+
+    <update id="updateUserInfo" parameterType="UserInfoChangeDto">
+        UPDATE users
+        SET name = #{name}, email = #{email}, phone_number = #{phoneNumber}
+        WHERE id = #{id}
+    </update>
+
+    <select id="getPasswordById" parameterType="String">
+        SELECT password
+        FROM users
+        WHERE id = #{id}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/UsersMapper.xml
+++ b/src/main/resources/mapper/UsersMapper.xml
@@ -40,4 +40,9 @@
         FROM users
         WHERE email = #{email}
     </select>
+    <update id="updatePassword" parameterType="UsersVO">
+        UPDATE users
+        SET password = #{password}
+        WHERE id = #{id}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
#15

## ✨ 작업 내용
아이디 찾기, 메일 인증번호 발송 및 인증, 비밀번호 변경, 비밀번호 일치 확인, 유저 정보 조회, 유저 정보 수정 구현했습니다.
소셜로그인 유저의 경우에는 유저 정보 수정에서 정보를 변경하면 안되기 때문에 소셜로그인 유저의 경우 소셜 타입을 함꼐 리턴하니 프론트엔드에서 1차로 처리해야할 것 같고, 혹시 처리가 안 됐을 경우를 대비해 2차로 서버에서 예외처리 해뒀습니다.

## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
흠 근데 이메일은 확실히 변경하면 안되는데 이름이랑 휴대폰 번호는..흠.... 바꿔도 되려나 싶습니다 여기에 대한 답변도 리뷰시 달아주시면 감사하겠습니다.